### PR TITLE
Add missing functions in Ecto.Type behaviour

### DIFF
--- a/lib/ecto_ltree/label_tree.ex
+++ b/lib/ecto_ltree/label_tree.ex
@@ -80,6 +80,12 @@ defmodule EctoLtree.LabelTree do
 
   def load(_), do: :error
 
+  @spec equal?(any, any) :: boolean
+  def equal?(a, b), do: a == b
+
+  @spec embed_as(any) :: :dump | :self
+  def embed_as(_), do: :self
+
   @doc """
   Returns the underlying schema type.
   """


### PR DESCRIPTION
In more recent versions of Ecto the Ecto.Type @behaviour the functions equal?/2 and embed_as/1 are no longer optional but mandatory thus breaking the current implementation.