### PR TITLE
Replace `use Mix.Config` with `import Config`

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,4 +1,4 @@
-use Mix.Config
+import Config
 
 if Mix.env() == :test do
   config :ecto_ltree, ecto_repos: [EctoLtree.TestRepo]


### PR DESCRIPTION
`use Mix.Config` was deprecated in favor of using `import Config`