### PR TITLE
Inline module var regex

### DIFF
--- a/lib/ecto_ltree/label_tree.ex
+++ b/lib/ecto_ltree/label_tree.ex
@@ -43,13 +43,12 @@ defmodule EctoLtree.LabelTree do
   def cast(_), do: :error
 
   @label_size_max 256
-  @label_regex ~r/[A-Za-z0-9_]{1,256}/
 
   @spec cast_label(String.t()) :: {:ok, String.t()} | :error
   defp cast_label(string) when is_binary(string) and byte_size(string) <= @label_size_max do
     string_length = String.length(string)
 
-    case Regex.run(@label_regex, string, return: :index) do
+    case Regex.run(~r/[A-Za-z0-9_]{1,256}/, string, return: :index) do
       [{0, last}] when last == string_length ->
         {:ok, string}
 


### PR DESCRIPTION
OTP28 removed the ability to use regexes in the module level vars. This change is backwards compatible with all prior OTP and Elixir implementations.